### PR TITLE
fix: allow artifacts without paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,9 +202,11 @@ async function main() {
 
       // pushing artifacts paths in global artifacts
       if ("artifacts" in job) {
-        for (const file of job.artifacts.paths) {
-          if (!ARTIFACTS.includes(file)) {
-            ARTIFACTS.push(file);
+        if ("paths" in job.artifacts) {
+          for (const file of job.artifacts.paths) {
+            if (!ARTIFACTS.includes(file)) {
+              ARTIFACTS.push(file);
+            }
           }
         }
       }


### PR DESCRIPTION
Allow artefacts definitions without the `paths`-block, for examples when you only want to use reports.