### PR TITLE
fix: use path.join for local include file

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ async function main() {
 
     for (const entry of ci.include) {
       if ("local" in entry) {
-        included += fs.readFileSync(process.cwd() + entry.local) + "\n";
+        included += fs.readFileSync(path.join(process.cwd(), entry.local)) + "\n";
       } else {
         throw "Only 'local' includes are supported at the moment.";
       }


### PR DESCRIPTION
Fixes the issue were you can't use `.gitlab/base.yml` as file in a `local`-block.
The use of `path.join()` should add the appropriate path separator

fixes #2