### PR TITLE
feat: support image.name

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,7 +210,8 @@ async function main() {
       }
 
       const workdir = `/${sha}`;
-      const image = job.image ?? DEFAULT.image;
+      const image = job.image?.name ? job.image.name : job.image ?? DEFAULT.image?.name ? DEFAULT.image.name : DEFAULT.image;
+      
       const cache = {
         policy: job.cache?.policy ?? DEFAULT.cache?.policy ?? "pull-push",
         paths:


### PR DESCRIPTION
Adds support to specify a docker image by `docker.image.name`  this should allow to use blocks like:

```
default:
  image:
    name: eu.gcr.io/company-global/ci-tools
```