### PR TITLE
Fix variables defined outside of default:

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,7 +204,7 @@ async function main() {
 
   // figuring out default values
   for (const key of GLOBAL_DEFAULT_KEY) {
-    DEFAULT[key] = ci.default ? ci.default[key] : ci[key];
+    DEFAULT[key] = (ci.default && ci.default[key]) ? ci.default[key] : ci[key];
   }
 
   // diff. actual jobs from reserved "config" keys


### PR DESCRIPTION
Fixes #20 

[This example](https://docs.gitlab.com/ee/ci/yaml/README.html#inherit) is valid, where a `default:` key exists and `variables:` is defined outside of it:
```yaml
default:
  image: 'ruby:2.4'
  before_script:
    - echo Hello World

variables:
  DOMAIN: example.com
  WEBHOOK_URL: https://my-webhook.example.com
```