### PR TITLE
Print stacktrace on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ async function main() {
   try {
     await docker.version();
   } catch (err) {
-    console.error(chalk.red(err));
+    console.error(chalk.red(err.stack));
     console.error("Docker daemon does not seem to be running.");
     process.exit(1);
   }
@@ -275,7 +275,7 @@ async function main() {
       console.log(chalk.bold(delimiter + "\n"));
 
       const onerror = async (err, container) => {
-        if (err) console.error(chalk.red(err));
+        if (err) console.error(chalk.red(err.stack));
         console.error(chalk.red("✘"), ` - ${name}\n`);
 
         if (container) await container.stop();


### PR DESCRIPTION
Print a full stack trace along with the error message to assist with debugging.

## Before

```
TypeError: Cannot read property 'indexOf' of undefined
```

## After

```
TypeError: Cannot read property 'indexOf' of undefined
    at Object.module.exports.parseRepositoryTag (/home/alexy/.config/yarn/global/node_modules/dockerode/lib/util.js:42:25)
    at Docker.pull (/home/alexy/.config/yarn/global/node_modules/dockerode/lib/docker.js:1411:23)
    at /home/alexy/.config/yarn/global/node_modules/glci/dist/cli.min.js:326:55
    at new Promise (<anonymous>)
    at main (/home/alexy/.config/yarn/global/node_modules/glci/dist/cli.min.js:326:15)
```
