### PR TITLE
feat: hack to bypass linux file permissions issues

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ pre:
     - mkdir -p node_modules/lodash
     - touch node_modules/lodash/index.js
     - touch foo.txt
-    - mkdir bar && touch bar/bar.txt
+    - mkdir -p bar && touch bar/bar.txt
   artifacts:
     paths:
       - foo.txt

--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ const path = require("path");
 const fs = require("fs-extra");
 const slugify = require("slugify");
 const { performance } = require("perf_hooks");
+const { promisify } = require("util");
+const osExec = promisify(require("child_process").exec);
 
 const define = require("./pre-defined");
 
@@ -73,11 +75,20 @@ function mkdirpRecSync(dir) {
   }
 }
 
-async function execCommands(workdir, container, commands, onerror) {
+async function execCommands({
+  workdir,
+  container,
+  commands,
+  onerror,
+  verbose = true,
+}) {
   const preparedCommands = typeof commands === "string" ? [commands] : commands;
 
   for (const command of preparedCommands) {
-    console.log(chalk.bold(chalk.green(command)));
+    if (verbose) {
+      console.log(chalk.bold(chalk.green(command)));
+    }
+
     let exec = null;
     let stream = null;
 
@@ -101,6 +112,7 @@ async function execCommands(workdir, container, commands, onerror) {
         if (inspect.ExitCode !== 0) reject();
         resolve();
       });
+
       container.modem.demuxStream(stream, process.stdout, {
         write: (err) => console.error(chalk.red(err.toString())),
       });
@@ -395,17 +407,41 @@ async function main() {
         if (job.before_script || DEFAULT.before_script) {
           const commands = job.before_script ?? DEFAULT.before_script;
 
-          await execCommands(workdir, container, commands, onerror);
+          await execCommands({ workdir, container, commands, onerror });
         }
 
         // running script
-        await execCommands(workdir, container, job.script, onerror);
+        await execCommands({
+          workdir,
+          container,
+          commands: job.script,
+          onerror,
+        });
 
         // running after_script
         if (job.after_script || DEFAULT.after_script) {
           const commands = job.after_script ?? DEFAULT.after_script;
 
-          await execCommands(workdir, container, commands, onerror);
+          await execCommands({ workdir, container, commands, onerror });
+        }
+
+        // hack for linux: chown -R <workdir>/ inside container to fix root permissions
+        // TODO: do other platforms need the hack ?
+        if (process.platform === "linux") {
+          const { stdout, stderr } = await osExec("id -u");
+
+          if (stderr) {
+            await onerror(stderr, container);
+          } else if (stdout.trim()) {
+            const commands = [`chown -R ${stdout.trim()}: ${workdir}`];
+            await execCommands({
+              workdir,
+              container,
+              commands,
+              onerror,
+              verbose: false,
+            });
+          }
         }
 
         // updating cache directory (if policy asks) after job ended


### PR DESCRIPTION
On Linux, all files created inside a Docker container are owned by `root` on host. To bypass this issue (and prevent needing to run `glci` with root permissions), we run a `chown -R <user_uid>:` on container workdir.