### PR TITLE
Abort if pulling Docker image fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -288,8 +288,7 @@ async function main() {
         await new Promise((resolve, reject) =>
           docker.pull(image, (err, stream) => {
             if (err) {
-                reject(err);
-                return;
+                return reject(err);
             }
 
             let downloading = false;

--- a/index.js
+++ b/index.js
@@ -286,8 +286,11 @@ async function main() {
       try {
         // pulling the image to use
         await new Promise((resolve, reject) =>
-          docker.pull(image, {}, (err, stream) => {
-            if (err) reject(err);
+          docker.pull(image, (err, stream) => {
+            if (err) {
+                reject(err);
+                return;
+            }
 
             let downloading = false;
             docker.modem.followProgress(


### PR DESCRIPTION
If pulling the CI Docker image fails, there should be some feedback to the user. By returning after rejecting the promise in the pull method, we can make sure the error message gets to the user.

Before:
<img width="695" alt="Screen Shot 2021-02-26 at 5 34 49 PM" src="https://user-images.githubusercontent.com/11386439/109328000-3c0f7300-7859-11eb-9a92-cf78eb64f167.png">

After:
<img width="694" alt="Screen Shot 2021-02-26 at 5 33 02 PM" src="https://user-images.githubusercontent.com/11386439/109328010-3e71cd00-7859-11eb-9d92-69b1a27e0230.png">
